### PR TITLE
The _all field is not longer supported

### DIFF
--- a/application/web/assets/js/project_search.jsx
+++ b/application/web/assets/js/project_search.jsx
@@ -166,7 +166,7 @@ export default class ProjectSearch extends React.Component {
                 auotfocus={true}
                 searchOnChange={true}
                 searchThrottleTime={750}
-                queryFields={["_all"]}
+                queryFields={["*"]}
               />
               <i
                 className="fas fa-info-circle fa-2x"


### PR DESCRIPTION
The _all field is not longer supported all fields mode will be used with * used for the fields parameter.

### Description

This change was made to fix the main search bar api call. When trying to search on all fields the code was using the deprecated _all field. The _all field is disabled by default in newer versions of Elastic and we can no longer use it. We converted the search to use the * wildcard which should do a all_fields query by default and mimic the response you would get before with _all.

### Issues Resolved

No linked Jira issue.

### Check List

- [ ] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
